### PR TITLE
fix: issue 68

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,11 @@
-import { codeInspectorPlugin } from 'code-inspector-plugin';
 import nextConst from 'next/constants.js';
 import { checkEnvs, tryLoadParentGitRepoEnv } from './scripts/utils.mjs';
+
+let codeInspectorPlugin;
+if (process.env.NODE_ENV === 'development') {
+  const { codeInspectorPlugin: plugin } = await import('code-inspector-plugin');
+  codeInspectorPlugin = plugin;
+}
 
 export default async function setup(phase) {
   tryLoadParentGitRepoEnv()
@@ -24,10 +29,10 @@ export default async function setup(phase) {
       dangerouslyAllowSVG: true,
     },
     turbopack: {
-      rules: codeInspectorPlugin({
+      rules: codeInspectorPlugin ? codeInspectorPlugin({
         bundler: 'turbopack',
         hideDomPathAttr: true,
-      })
+      }) : undefined
     },
     webpack: (config, { webpack, nextRuntime }) => {
       // TODO 使用 turbopack 后是否需要？

--- a/package.json
+++ b/package.json
@@ -61,7 +61,9 @@
     "sharp": "^0.33.5",
     "uvcanvas": "^0.2.1",
     "zod": " 4.1.11 ",
-    "zod-validation-error": "4.0.2"
+    "tsx": "4.19.3",
+    "zod-validation-error": "4.0.2",
+    "zx": "8.1.5"
   },
   "devDependencies": {
     "@faker-js/faker": "^8.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       sharp:
         specifier: ^0.33.5
         version: 0.33.5
+      tsx:
+        specifier: 4.19.3
+        version: 4.19.3
       uvcanvas:
         specifier: ^0.2.1
         version: 0.2.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(acorn@8.14.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -125,6 +128,9 @@ importers:
       zod-validation-error:
         specifier: 4.0.2
         version: 4.0.2(zod@4.1.11)
+      zx:
+        specifier: 8.1.5
+        version: 8.1.5
     devDependencies:
       '@faker-js/faker':
         specifier: ^8.4.1
@@ -189,9 +195,6 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@4.1.17)
-      tsx:
-        specifier: 4.19.3
-        version: 4.19.3
       typescript:
         specifier: 5.9.2
         version: 5.9.2
@@ -204,9 +207,6 @@ importers:
       vitest:
         specifier: 3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@20.17.28)(lightningcss@1.30.2)
-      zx:
-        specifier: 8.1.5
-        version: 8.1.5
 
 packages:
 


### PR DESCRIPTION
Close: [Issue 68](https://github.com/Y80/bmm/issues/68)

1. 将tsx和zx依赖添加到dependencies
2. 将 code-inspector-plugin 的导入改为动态导入，只在开发环境中加载